### PR TITLE
Update version in package.json for prerelease changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onshape/ng-i18next",
-  "version": "0.3.16",
+  "version": "0.3.17-1",
   "description": "AngularJS filter and directive for i18next (i18next by Jan Mühlemann)",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
I forgot to change the `onshape/ng-i18next` version in `package.json`.  (Using the prerelease version still said `warning " > @onshape/ng-i18next@0.3.17-0" has incorrect peer dependency "i18next@~2.0.0".`.)